### PR TITLE
Blocked cyclic based multi-GPU blocked cholesky + clone_here bug fix

### DIFF
--- a/examples/blocked_cholesky_gpu.py
+++ b/examples/blocked_cholesky_gpu.py
@@ -3,7 +3,7 @@ A naive implementation of blocked Cholesky using Numba kernels on CPUs.
 """
 
 import numpy as np
-# import cupy
+#import cupy
 from numba import jit, void, float64
 import math
 import time
@@ -23,6 +23,10 @@ from cupy.cuda import device
 from cupy.linalg import _util
 
 from scipy import linalg
+import sys
+
+block_size = int(sys.argv[1])
+n = block_size*int(sys.argv[2])
 
 loc = gpu
 
@@ -59,18 +63,17 @@ def ltriang_solve(a, b):
         raise ValueError("Input array shapes are not compatible.")
     if a.shape[0] != a.shape[1]:
         raise ValueError("Array for back substitution is not square.")
-    # For the implementation here, just assume lower triangular.
+    #For the implementation here, just assume lower triangular.
     for i in range(a.shape[0]):
         b[i] /= a[i,i]
         b[i+1:] -= a[i+1:,i:i+1] * b[i:i+1]
     return b.T
 
-#comments would repack the data to column-major
+#comments would repack the data to column - major
 def cupy_trsm_wrapper(a, b):
     cublas_handle = device.get_cublas_handle()
     trsm = cublas.dtrsm
     uplo = cublas.CUBLAS_FILL_MODE_LOWER
-
     a = cp.array(a, dtype=np.float64, order='F')
     b = cp.array(b, dtype=np.float64, order='F')
     print("Running cupy trsm on device: ", a.device)
@@ -120,7 +123,7 @@ def cholesky_blocked_inplace(a):
     if a.shape[0] != a.shape[1]:
         raise ValueError("Non-square blocks are not supported.")
 
-    # Define task spaces
+    #Define task spaces
     gemm1 = TaskSpace("gemm1")        # Inter-block GEMM
     subcholesky = TaskSpace("subcholesky")  # Cholesky on block
     gemm2 = TaskSpace("gemm2")        # Inter-block GEMM
@@ -128,16 +131,15 @@ def cholesky_blocked_inplace(a):
 
     for j in range(a.shape[0]):
         for k in range(j):
-            # Inter-block GEMM
+            #Inter - block GEMM
             @spawn(gemm1[j, k], [solve[j, k]], placement=loc)
             def t1():
                 out = clone_here(a[j,j])  # Move data to the current device
                 rhs = clone_here(a[j,k])
-
                 out = update(rhs, rhs, out)
                 copy(a[j,j], out)  # Move the result to the global array
 
-        # Cholesky on block
+        #Cholesky on block
         @spawn(subcholesky[j], [gemm1[j, 0:j]], placement=loc)
         def t2():
             dblock = clone_here(a[j, j])
@@ -146,17 +148,16 @@ def cholesky_blocked_inplace(a):
 
         for i in range(j+1, a.shape[0]):
             for k in range(j):
-                # Inter-block GEMM
+                #Inter - block GEMM
                 @spawn(gemm2[i, j, k], [solve[j, k], solve[i, k]], placement=loc)
                 def t3():
                     out = clone_here(a[i,j])  # Move data to the current device
                     rhs1 = clone_here(a[i,k])
                     rhs2 = clone_here(a[j,k])
-
                     out = update(rhs1, rhs2, out)
                     copy(a[i,j], out)  # Move the result to the global array
 
-            # Triangular solve
+            #Triangular solve
             @spawn(solve[i, j], [gemm2[i, j, 0:j], subcholesky[j]], placement=loc)
             def t4():
                 factor = clone_here(a[j, j])
@@ -172,22 +173,19 @@ def cholesky_blocked_inplace(a):
 def main():
     @spawn(placement=cpu)
     async def test_blocked_cholesky():
-        # Configure environment
-        block_size = 32*5
-        n = block_size*16
         assert not n % block_size
 
         np.random.seed(10)
-        # Construct input data
+        #Construct input data
         a = np.random.rand(n, n)
         a = a @ a.T
 
-        # Copy and layout input
+        #Copy and layout input
         a1 = a.copy()
         ap = a1.reshape(n // block_size, block_size, n // block_size, block_size).swapaxes(1,2)
         start = time.perf_counter()
 
-        # Call Parla Cholesky result and wait for completion
+        #Call Parla Cholesky result and wait for completion
         await cholesky_blocked_inplace(ap)
 
         end = time.perf_counter()
@@ -195,7 +193,7 @@ def main():
 
         print("Truth", linalg.cholesky(a).T)
 
-        # Check result
+        #Check result
         computed_L = np.tril(a1)
         print("Soln", computed_L)
         error = np.max(np.absolute(a-computed_L @ computed_L.T))

--- a/examples/blocked_cholesky_multigpu.py
+++ b/examples/blocked_cholesky_multigpu.py
@@ -1,0 +1,275 @@
+"""
+A naive implementation of blocked Cholesky using Numba kernels on CPUs.
+"""
+
+import numpy as np
+#import cupy
+from numba import jit, void, float64
+import math
+import time
+
+from parla import Parla, get_all_devices
+from parla.array import copy, clone_here
+
+from parla.cuda import gpu
+from parla.cpu import cpu
+
+from parla.function_decorators import specialized
+from parla.tasks import *
+
+import cupy as cp
+from cupy.cuda import cublas
+from cupy.cuda import device
+from cupy.linalg import _util
+
+from scipy import linalg
+import sys
+
+loc = gpu
+
+gpu_arrs = []
+
+EXEC_MULT_GPU = True
+#EXEC_MULT_GPU = False
+
+#Configure environment
+block_size = int(sys.argv[1])
+n = block_size*int(sys.argv[2])
+
+@specialized
+@jit(float64[:,:](float64[:,:]), nopython=True, nogil=True)
+def cholesky(a):
+  """
+  Naive version of dpotrf. Write results into lower triangle of the input array.
+  """
+  if a.shape[0] != a.shape[1]:
+    raise ValueError("A square array is required.")
+  for j in range(a.shape[0]):
+    a[j,j] = math.sqrt(a[j,j] - (a[j,:j] * a[j,:j]).sum())
+    for i in range(j+1, a.shape[0]):
+      a[i,j] -= (a[i,:j] * a[j,:j]).sum()
+      a[i,j] /= a[j,j]
+  return a
+
+@cholesky.variant(gpu)
+def choleksy_gpu(a):
+  a = cp.linalg.cholesky(a)
+  return a
+
+@specialized
+@jit(float64[:,:](float64[:,:], float64[:,:]), nopython=True, nogil=True)
+def ltriang_solve(a, b):
+  """
+  This is a naive version of dtrsm. The result is written over the input array `b`.
+  """
+  b = b.T
+  if a.shape[0] != b.shape[0]:
+    raise ValueError("Input array shapes are not compatible.")
+  if a.shape[0] != a.shape[1]:
+    raise ValueError("Array for back substitution is not square.")
+  #For the implementation here, just assume lower triangular.
+  for i in range(a.shape[0]):
+    b[i] /= a[i,i]
+    b[i+1:] -= a[i+1:,i:i+1] * b[i:i+1]
+  return b.T
+
+#comments would repack the data to column - major
+def cupy_trsm_wrapper(a, b):
+  cublas_handle = device.get_cublas_handle()
+  trsm = cublas.dtrsm
+  uplo = cublas.CUBLAS_FILL_MODE_LOWER
+
+  a = cp.array(a, dtype=np.float64, order='F')
+  b = cp.array(b, dtype=np.float64, order='F')
+  trans = cublas.CUBLAS_OP_T
+  side = cublas.CUBLAS_SIDE_RIGHT
+
+  diag = cublas.CUBLAS_DIAG_NON_UNIT
+  m, n = (b.side, 1) if b.ndim == 1 else b.shape
+  trsm(cublas_handle, side, uplo, trans, diag, m, n, 1.0, a.data.ptr, m, b.data.ptr, m)
+  return b
+
+@ltriang_solve.variant(gpu)
+def ltriang_solve_gpu(a, b):
+  b = cupy_trsm_wrapper(a, b)
+  return b
+
+def update_kernel(a, b, c):
+  c -= a @ b.T
+  return c
+
+@specialized
+def update(a, b, c):
+  c = update_kernel(a, b, c)
+  return c
+
+@update.variant(gpu)
+def update_gpu(a, b, c):
+  c = update_kernel(a, b, c)
+  return c
+
+def cholesky_blocked_inplace(a, num_gpus):
+  """
+  This is a less naive version of dpotrf with one level of blocking.
+  Blocks are currently assumed to evenly divide the axes lengths.
+  The input array 4 dimensional. The first and second index select
+  the block (row first, then column). The third and fourth index
+  select the entry within the given block.
+  """
+  if a.shape[0] * a.shape[2] != a.shape[1] * a.shape[3]:
+    raise ValueError("A square matrix is required.")
+  if a.shape[0] != a.shape[1]:
+    raise ValueError("Non-square blocks are not supported.")
+
+  #Define task spaces
+  gemm1 = TaskSpace("gemm1")        # Inter-block GEMM
+  subcholesky = TaskSpace("subcholesky")  # Cholesky on block
+  gemm2 = TaskSpace("gemm2")        # Inter-block GEMM
+  solve = TaskSpace("solve")        # Triangular solve
+
+  for j in range(a.shape[0]):
+    for k in range(j):
+      #Inter - block GEMM
+      @spawn(gemm1[j, k], [solve[j, k]], placement=[gpu(j%num_gpus)])
+      def t1():
+        out = get_gpu_memory(j, j, num_gpus)
+        rhs = get_gpu_memory(j, k, num_gpus)
+        out = update(rhs, rhs, out)
+        set_gpu_memory_from_gpu(j, j, num_gpus, out)
+
+    #Cholesky on block
+    @spawn(subcholesky[j], [gemm1[j, 0:j]], placement=[gpu(j%num_gpus)])
+    def t2():
+      dblock = get_gpu_memory(j, j, num_gpus) 
+      dblock = cholesky(dblock)
+      set_gpu_memory_from_gpu(j, j, num_gpus, dblock)
+
+    for i in range(j+1, a.shape[0]):
+      for k in range(j):
+        #Inter - block GEMM
+        @spawn(gemm2[i, j, k], [solve[j, k], solve[i, k]], placement=[gpu(i%num_gpus)])
+        def t3():
+          out = get_gpu_memory(i, j, num_gpus)
+          rhs1 = get_gpu_memory(i, k, num_gpus)
+          rhs2 = get_gpu_memory(j, k, num_gpus)
+          out = update(rhs1, rhs2, out)
+          set_gpu_memory_from_gpu(i, j, num_gpus, out)
+
+      #Triangular solve
+      @spawn(solve[i, j], [gemm2[i, j, 0:j], subcholesky[j]], placement=[gpu(i%num_gpus)])
+      def t4():
+        factor = get_gpu_memory(j, j, num_gpus)
+        panel  = get_gpu_memory(i, j, num_gpus)
+        out = ltriang_solve(factor, panel)
+        set_gpu_memory_from_gpu(i, j, num_gpus, out)
+
+  return subcholesky[a.shape[0]-1]
+
+def asarray_sync(src):
+  if src.device != cp.cuda.Device():
+    dst = cp.ndarray(src.shape)
+    dst.data.copy_from_device_async(src.data, src.nbytes, \
+                                    cp.cuda.get_current_stream())
+  else:
+    dst = cp.asarray(src)
+  return dst
+
+def allocate_gpu_memory(i:int, r:int, n:int, b:int):
+  with cp.cuda.Device(i):
+    print("\tAllocate device:", i, "...")
+    prealloced = cp.ndarray([r, n // b, b, b])
+    gpu_arrs.append(prealloced)
+
+def get_gpu_memory(i:int, j:int, num_gpus:int):
+  dev_id   = i % num_gpus
+  local_id = i // num_gpus
+  src = gpu_arrs[dev_id][local_id][j]
+  dst = asarray_sync(src)
+  return dst
+
+def set_gpu_memory_from_gpu(i:int, j:int, num_gpus:int, v):
+  dev_id   = i % num_gpus
+  local_id = i // num_gpus
+  gpu_arrs[dev_id][local_id][j] = v
+
+def set_gpu_memory_from_cpu(a, num_gpus):
+  for j in range(a.shape[0]):
+    dev_id   = j % num_gpus 
+    local_id = j // num_gpus 
+    with cp.cuda.Device(dev_id):
+      gpu_arrs[dev_id][local_id] = cp.array(a[j], copy=True)
+
+def main():
+  num_gpus = cp.cuda.runtime.getDeviceCount()
+  @spawn(placement=cpu)
+  async def test_blocked_cholesky():
+    print("Block size=", block_size, " and total array size=", n)
+    assert not n % block_size
+
+    print("Allocate memory..")
+    for d in range(num_gpus):
+      row_size = n // (block_size * num_gpus)
+      if d < ((n / block_size) % num_gpus):
+        row_size += 1
+      if row_size > 0:
+        allocate_gpu_memory(d, row_size, n, block_size)
+    print("Allocate memory done..")
+
+    np.random.seed(10)
+
+    print("Random number generate..")
+    #Construct input data
+    a = np.random.rand(n, n)
+    a = a @ a.T
+    print("Random number generate done..")
+
+    print("Copy a to a1..")
+    #Copy and layout input
+    a1 = a.copy()
+    print("Copying done..")
+    print("Shaping starts..")
+    ap = a1.reshape(n // block_size, block_size, n // block_size, block_size).swapaxes(1,2)
+    print("Shaping done..")
+    set_gpu_memory_from_cpu(ap, num_gpus)
+
+    for i in range(len(gpu_arrs)):
+      print("Device ", i, " arrays are on ", gpu_arrs[i].device);
+    print("Calculate starts..")
+    start = time.perf_counter()
+
+    #Call Parla Cholesky result and wait for completion
+    await cholesky_blocked_inplace(ap, num_gpus)
+
+    end = time.perf_counter()
+    print(end - start, "seconds")
+    print("Calculate done..")
+
+    for i in range(len(gpu_arrs)):
+      print("Device ", i, " arrays are on ", gpu_arrs[i].device);
+
+    for d in range(len(gpu_arrs)):
+      print("Device:", d, " swap array..")
+      gpu_arrs[d] = cp.swapaxes(gpu_arrs[d], 2, 1)
+      print("Device:", d, " swap done..")
+
+    cpu_arrs = np.empty([n // block_size,
+                         block_size,
+                         n // block_size,
+                         block_size], dtype=float)
+    for r_num in range(n // block_size):
+      dev_id   = r_num % num_gpus
+      local_id = r_num // num_gpus
+      cpu_arrs[r_num] = cp.asnumpy(gpu_arrs[dev_id][local_id])
+    cpu_arrs = cpu_arrs.reshape(n, n)
+    print("Truth", linalg.cholesky(a).T)
+
+    #Check result
+    computed_L = np.tril(cpu_arrs)
+    print("Soln", computed_L)
+    error = np.max(np.absolute(a-computed_L @ computed_L.T))
+    print("Error", error)
+    assert(error < 1E-8)
+
+if __name__ == '__main__':
+    with Parla():
+        main()

--- a/examples/blocked_cholesky_multigpu.py
+++ b/examples/blocked_cholesky_multigpu.py
@@ -2,8 +2,8 @@
 A naive implementation of blocked Cholesky using Numba kernels on CPUs.
 """
 
+import logging
 import numpy as np
-#import cupy
 from numba import jit, void, float64
 import math
 import time
@@ -20,19 +20,18 @@ from parla.tasks import *
 import cupy as cp
 from cupy.cuda import cublas
 from cupy.cuda import device
-from cupy.linalg import _util
+#from cupy.linalg import _util
 
 from scipy import linalg
 import sys
+
+logger = logging.getLogger(__name__)
 
 loc = gpu
 
 gpu_arrs = []
 
-EXEC_MULT_GPU = True
-#EXEC_MULT_GPU = False
-
-#Configure environment
+# Configure environment
 block_size = int(sys.argv[1])
 n = block_size*int(sys.argv[2])
 
@@ -67,13 +66,13 @@ def ltriang_solve(a, b):
     raise ValueError("Input array shapes are not compatible.")
   if a.shape[0] != a.shape[1]:
     raise ValueError("Array for back substitution is not square.")
-  #For the implementation here, just assume lower triangular.
+  # For the implementation here, just assume lower triangular.
   for i in range(a.shape[0]):
     b[i] /= a[i,i]
     b[i+1:] -= a[i+1:,i:i+1] * b[i:i+1]
   return b.T
 
-#comments would repack the data to column - major
+# Comments would repack the data to column - major
 def cupy_trsm_wrapper(a, b):
   cublas_handle = device.get_cublas_handle()
   trsm = cublas.dtrsm
@@ -121,7 +120,7 @@ def cholesky_blocked_inplace(a, num_gpus):
   if a.shape[0] != a.shape[1]:
     raise ValueError("Non-square blocks are not supported.")
 
-  #Define task spaces
+  # Define task spaces
   gemm1 = TaskSpace("gemm1")        # Inter-block GEMM
   subcholesky = TaskSpace("subcholesky")  # Cholesky on block
   gemm2 = TaskSpace("gemm2")        # Inter-block GEMM
@@ -129,7 +128,7 @@ def cholesky_blocked_inplace(a, num_gpus):
 
   for j in range(a.shape[0]):
     for k in range(j):
-      #Inter - block GEMM
+      # Inter - block GEMM
       @spawn(gemm1[j, k], [solve[j, k]], placement=[gpu(j%num_gpus)])
       def t1():
         out = get_gpu_memory(j, j, num_gpus)
@@ -137,7 +136,7 @@ def cholesky_blocked_inplace(a, num_gpus):
         out = update(rhs, rhs, out)
         set_gpu_memory_from_gpu(j, j, num_gpus, out)
 
-    #Cholesky on block
+    # Cholesky on block
     @spawn(subcholesky[j], [gemm1[j, 0:j]], placement=[gpu(j%num_gpus)])
     def t2():
       dblock = get_gpu_memory(j, j, num_gpus) 
@@ -146,7 +145,7 @@ def cholesky_blocked_inplace(a, num_gpus):
 
     for i in range(j+1, a.shape[0]):
       for k in range(j):
-        #Inter - block GEMM
+        # Inter - block GEMM
         @spawn(gemm2[i, j, k], [solve[j, k], solve[i, k]], placement=[gpu(i%num_gpus)])
         def t3():
           out = get_gpu_memory(i, j, num_gpus)
@@ -155,7 +154,7 @@ def cholesky_blocked_inplace(a, num_gpus):
           out = update(rhs1, rhs2, out)
           set_gpu_memory_from_gpu(i, j, num_gpus, out)
 
-      #Triangular solve
+      # Triangular solve
       @spawn(solve[i, j], [gemm2[i, j, 0:j], subcholesky[j]], placement=[gpu(i%num_gpus)])
       def t4():
         factor = get_gpu_memory(j, j, num_gpus)
@@ -165,18 +164,9 @@ def cholesky_blocked_inplace(a, num_gpus):
 
   return subcholesky[a.shape[0]-1]
 
-def asarray_sync(src):
-  if src.device != cp.cuda.Device():
-    dst = cp.ndarray(src.shape)
-    dst.data.copy_from_device_async(src.data, src.nbytes, \
-                                    cp.cuda.get_current_stream())
-  else:
-    dst = cp.asarray(src)
-  return dst
-
 def allocate_gpu_memory(i:int, r:int, n:int, b:int):
   with cp.cuda.Device(i):
-    print("\tAllocate device:", i, "...")
+    logger.debug("\tAllocate device:", i, "...")
     prealloced = cp.ndarray([r, n // b, b, b])
     gpu_arrs.append(prealloced)
 
@@ -184,7 +174,7 @@ def get_gpu_memory(i:int, j:int, num_gpus:int):
   dev_id   = i % num_gpus
   local_id = i // num_gpus
   src = gpu_arrs[dev_id][local_id][j]
-  dst = asarray_sync(src)
+  dst = clone_here(src)
   return dst
 
 def set_gpu_memory_from_gpu(i:int, j:int, num_gpus:int, v):
@@ -203,54 +193,54 @@ def main():
   num_gpus = cp.cuda.runtime.getDeviceCount()
   @spawn(placement=cpu)
   async def test_blocked_cholesky():
-    print("Block size=", block_size, " and total array size=", n)
+    logger.debug("Block size=", block_size, " and total array size=", n)
     assert not n % block_size
 
-    print("Allocate memory..")
+    logger.debug("Allocate memory..")
     for d in range(num_gpus):
       row_size = n // (block_size * num_gpus)
       if d < ((n / block_size) % num_gpus):
         row_size += 1
       if row_size > 0:
         allocate_gpu_memory(d, row_size, n, block_size)
-    print("Allocate memory done..")
+    logger.debug("Allocate memory done..")
 
     np.random.seed(10)
 
-    print("Random number generate..")
-    #Construct input data
+    logger.debug("Random number generate..")
+    # Construct input data
     a = np.random.rand(n, n)
     a = a @ a.T
-    print("Random number generate done..")
+    logger.debug("Random number generate done..")
 
-    print("Copy a to a1..")
-    #Copy and layout input
+    logger.debug("Copy a to a1..")
+    # Copy and layout input
     a1 = a.copy()
-    print("Copying done..")
-    print("Shaping starts..")
+    logger.debug("Copying done..")
+    logger.debug("Shaping starts..")
     ap = a1.reshape(n // block_size, block_size, n // block_size, block_size).swapaxes(1,2)
-    print("Shaping done..")
+    logger.debug("Shaping done..")
     set_gpu_memory_from_cpu(ap, num_gpus)
 
     for i in range(len(gpu_arrs)):
-      print("Device ", i, " arrays are on ", gpu_arrs[i].device);
-    print("Calculate starts..")
+      logger.debug("Device ", i, " arrays are on ", gpu_arrs[i].device);
+    logger.debug("Calculate starts..")
     start = time.perf_counter()
 
-    #Call Parla Cholesky result and wait for completion
+    # Call Parla Cholesky result and wait for completion
     await cholesky_blocked_inplace(ap, num_gpus)
 
     end = time.perf_counter()
     print(end - start, "seconds")
-    print("Calculate done..")
+    logger.debug("Calculate done..")
 
     for i in range(len(gpu_arrs)):
-      print("Device ", i, " arrays are on ", gpu_arrs[i].device);
+      logger.debug("Device ", i, " arrays are on ", gpu_arrs[i].device);
 
     for d in range(len(gpu_arrs)):
-      print("Device:", d, " swap array..")
+      logger.debug("Device:", d, " swap array..")
       gpu_arrs[d] = cp.swapaxes(gpu_arrs[d], 2, 1)
-      print("Device:", d, " swap done..")
+      logger.debug("Device:", d, " swap done..")
 
     cpu_arrs = np.empty([n // block_size,
                          block_size,
@@ -263,7 +253,7 @@ def main():
     cpu_arrs = cpu_arrs.reshape(n, n)
     print("Truth", linalg.cholesky(a).T)
 
-    #Check result
+    # Check result
     computed_L = np.tril(cpu_arrs)
     print("Soln", computed_L)
     error = np.max(np.absolute(a-computed_L @ computed_L.T))

--- a/parla/array.py
+++ b/parla/array.py
@@ -5,6 +5,7 @@ from typing import Dict
 # FIXME: This load of numpy causes problems if numpy is multiloaded. So this breaks using VECs with parla tasks.
 #  Loading numpy locally works for some things, but not for the array._register_array_type call.
 import numpy as np
+import cupy as cp
 
 from parla.device import Memory
 from parla.tasks import get_current_devices
@@ -127,7 +128,8 @@ def clone_here(source, kind=None):
     """
     if is_array(source):
         # TODO: How to correctly handle multiple devices.
-        return get_current_devices()[0].memory(kind)(source)
+        #return get_current_devices()[0].memory(kind)(source)
+        return cp.asarray(source)
     else:
         raise TypeError("Array required, given value of type {}".format(type(source)))
 

--- a/parla/array.py
+++ b/parla/array.py
@@ -128,11 +128,9 @@ def clone_here(source, kind=None):
     """
     if is_array(source):
         # TODO: How to correctly handle multiple devices.
-        #return get_current_devices()[0].memory(kind)(source)
-        return cp.asarray(source)
+        return get_current_devices()[0].memory(kind)(source)
     else:
         raise TypeError("Array required, given value of type {}".format(type(source)))
-
 
 def storage_size(*arrays):
     """

--- a/parla/array.py
+++ b/parla/array.py
@@ -5,7 +5,6 @@ from typing import Dict
 # FIXME: This load of numpy causes problems if numpy is multiloaded. So this breaks using VECs with parla tasks.
 #  Loading numpy locally works for some things, but not for the array._register_array_type call.
 import numpy as np
-import cupy as cp
 
 from parla.device import Memory
 from parla.tasks import get_current_devices
@@ -131,6 +130,7 @@ def clone_here(source, kind=None):
         return get_current_devices()[0].memory(kind)(source)
     else:
         raise TypeError("Array required, given value of type {}".format(type(source)))
+
 
 def storage_size(*arrays):
     """

--- a/parla/cuda.py
+++ b/parla/cuda.py
@@ -11,6 +11,8 @@ from . import device
 from .device import *
 from .environments import EnvironmentComponentInstance, TaskEnvironment, EnvironmentComponentDescriptor
 
+import numpy
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -50,13 +52,28 @@ class _GPUMemory(Memory):
     def np(self):
         return _DeviceCUPy(self.device)
 
+    def asarray_async(self, src):
+      dst = cupy.ndarray(src.shape)
+      dst.data.copy_from_device_async(src.data, src.nbytes,
+                                      cupy.cuda.get_current_stream())
+      return dst
+
     def __call__(self, target):
-        with self.device._device_context():
-            if cupy.cuda.Device() != getattr(target, "device", None):
-                logger.debug("Moving data: %r => %r", getattr(target, "device", None), cupy.cuda.Device())
-                return cupy.asarray(target)
-            else:
-                return target
+        # TODO Several threads could share the same device object.
+        #      It causes data race and CUDA context is incorrectly set.
+        #      For now, this remove assumes that one device is always
+        #      assigned to one task.
+        #with self.device._device_context():
+        if type(target) is numpy.ndarray:
+            logger.debug("Moving data: CPU => %r", cupy.cuda.Device())
+            return cupy.asarray(target)
+        elif type(target) is cupy.ndarray and \
+             cupy.cuda.Device() != getattr(target, "device", None):
+            logger.debug("Moving data: %r => %r",
+                         getattr(target, "device", None), cupy.cuda.Device())
+            return self.asarray_async(target)
+        else:
+            return target
 
 
 class _GPUDevice(Device):

--- a/parla/cuda.py
+++ b/parla/cuda.py
@@ -63,8 +63,10 @@ class _GPUMemory(Memory):
         #      It causes data race and CUDA context is incorrectly set.
         #      For now, this remove assumes that one device is always
         #      assigned to one task.
+        # FIXME This code breaks the semantics since a different device
+        #       could copy data on the current device to a remote device.
         #with self.device._device_context():
-        if type(target) is numpy.ndarray:
+        if isinstance(target, numpy.ndarray):
             logger.debug("Moving data: CPU => %r", cupy.cuda.Device())
             return cupy.asarray(target)
         elif type(target) is cupy.ndarray and \


### PR DESCRIPTION
This PR contains two items:
1) blocked cyclic based multi-GPU blocked cholesky using row partitioning
2) `clone_here` fix; `cupy.as_array()` could not handle multiple CUDA stream well. This PR replace it with asynchronous copy specifying a target stream. `_GPUMemory` managed CUDA device object and multiple threads shared this global object without synchronization. This PR removed on-demand CUDA context change while `clone_here()` with an assumption that each task is only assigned a single GPU. Note that these are not the final fixes. We expect `cupy` will open their fixes soon and we will move the context object to thread local memory to avoid data race.