### PR TITLE
Change CPU architecture to have one device.

### DIFF
--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -638,7 +638,7 @@ class Scheduler(ControllableThread, SchedulerContext):
     def __init__(self, environments: Collection[TaskEnvironment], n_threads: int = None, period: float = 0.01,
                  max_worker_queue_depth: int = 2):
         super().__init__()
-        n_threads = n_threads or len(environments)
+        n_threads = n_threads or sum(d.resources.get("vcus", 1) for e in environments for d in e.placement)
         self._environments = TaskEnvironmentRegistry(*environments)
         self._exceptions = []
         self._active_task_count = 1 # Start with one count that is removed when the scheduler is "exited"
@@ -787,12 +787,12 @@ class Scheduler(ControllableThread, SchedulerContext):
 
                 if not task.assigned:
                     task._assignment_tries = getattr(task, "_assignment_tries", 0) + 1
-                    if task._assignment_tries > _ASSIGNMENT_FAILURE_WARNING_LIMIT:
-                        logger.warning("Task %r: Failed to assign devices. The required resources may not be "
-                                       "available on this machine at all.\n"
-                                       "Available resources: %r\n"
-                                       "Unallocated resources: %r",
-                                       task, self._available_resources, self._unassigned_resources)
+                    # if task._assignment_tries > _ASSIGNMENT_FAILURE_WARNING_LIMIT:
+                    #     logger.warning("Task %r: Failed to assign devices. The required resources may not be "
+                    #                    "available on this machine at all.\n"
+                    #                    "Available resources: %r\n"
+                    #                    "Unallocated resources: %r",
+                    #                    task, self._available_resources, self._unassigned_resources)
                     # Put task we cannot assign resources to at the back of the queue
                     logger.debug("Task %r: Failed to assign", task)
                     self.enqueue_task(task)

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -2,6 +2,8 @@ import logging
 import threading
 from time import sleep
 
+import pytest
+
 from parla import Parla, TaskEnvironment
 from parla.cpu import cpu
 from parla.environments import EnvironmentComponentInstance, EnvironmentComponentDescriptor
@@ -85,6 +87,7 @@ def test_component_initialized():
         assert task_results == ["test"]
 
 
+@pytest.mark.skipif(len(cpu.devices) < 2, reason="Run with PARLA_CPU_ARCHITECTURE=cores")
 def test_multiple_environments_fixed_assignment():
     # Dummy environments with no components for testing.
     environments = [TaskEnvironment(placement=[cpu(0)], components=[DummyComponent("foo")]),
@@ -102,6 +105,7 @@ def test_multiple_environments_fixed_assignment():
         assert set(task_results) == {"foo", "bar"}
 
 
+@pytest.mark.skipif(len(cpu.devices) < 2, reason="Run with PARLA_CPU_ARCHITECTURE=cores")
 def test_multiple_environments_free_assignment():
     # Dummy environments with no components for testing.
     environments = [TaskEnvironment(placement=[cpu(0)], components=[DummyComponent("foo")]),
@@ -126,6 +130,7 @@ def test_multiple_environments_free_assignment():
             assert set(task_results) == {"foo", "bar"}
 
 
+@pytest.mark.skipif(len(cpu.devices) < 2, reason="Run with PARLA_CPU_ARCHITECTURE=cores")
 def test_multiple_environments_tagged():
     # Dummy environments with no components for testing.
     environments = [TaskEnvironment(placement=[cpu(0)], components=[DummyComponent("foo")], tags=(threading,)),
@@ -149,6 +154,7 @@ def test_multiple_environments_tagged():
             assert task_results == ["bar"]
 
 
+@pytest.mark.skipif(len(cpu.devices) < 2, reason="Run with PARLA_CPU_ARCHITECTURE=cores")
 def test_multiple_environments_best_fit():
     # Dummy environments with no components for testing.
     environments = [TaskEnvironment(placement=[cpu(0)], components=[DummyComponent("foo")]),
@@ -190,6 +196,7 @@ def test_multiple_environments_best_fit():
             assert task_results == ["bar", "bar", "bar"]
 
 
+@pytest.mark.skipif(len(cpu.devices) < 5, reason="Run with PARLA_CPU_ARCHITECTURE=cores")
 def test_multiple_environments_less_good_fit():
     # Dummy environments with no components for testing.
     environments = [TaskEnvironment(placement=[cpu(0), cpu(1)], components=[DummyComponent("foo")]),


### PR DESCRIPTION
This adds a configuration env var PARLA_CPU_ARCHITECTURE.
It supports cores and whole.

The tests have to run in both modes to cover all the tests.