### PR TITLE
Datamovement task for each task and matmul experiment setup

### DIFF
--- a/examples/matmul_explicitmove.py
+++ b/examples/matmul_explicitmove.py
@@ -14,9 +14,7 @@ from parla.cpu import cpu
 from parla.cuda import gpu
 from parla.function_decorators import specialized
 from parla.ldevice import LDeviceSequenceBlocked
-from parla.tasks import spawn, TaskSpace, CompletedTaskSpace, reserve_persistent_memory
-from parla.parray import asarray_batch
-
+from parla.tasks import spawn, TaskSpace, CompletedTaskSpace
 def main():
     ngpus = int(sys.argv[1])
     repetitions = int(sys.argv[2])
@@ -50,15 +48,10 @@ def main():
         c_part.append(np.empty((c_dim, n), np.float32, order = 'F'))
 
     previous = None
-
-    # 1. NEW: convert to parray in batch
-    a_part, b_part, c_part = asarray_batch(a_part, b_part, c_part)
-
     for repetition in range(repetitions):
         # Now compute a @ b.T and write the output to c
         deps = [previous] if previous is not None else []
-        # 2. NEW: input/inout
-        @spawn(placement = cpu, dependencies = deps, input=[*a_part, *b_part], inout=[*c_part])
+        @spawn(placement = cpu, dependencies = deps)
         async def run_matmul():
             start = time.perf_counter()
             matmul = TaskSpace("matmul")
@@ -70,11 +63,12 @@ def main():
                     memsize = c_block.nbytes
                     if i != j:
                         memsize += b_block.nbytes
-
-                    # 3. NEW: input/output
-                    @spawn(matmul[i, j], dependencies=[matmul[0:i, j], matmul[i, 0:j]], placement = gpu, memory=memsize, input=[a_block, b_block], output=[c_block])
+                    @spawn(matmul[i, j], dependencies=[matmul[0:i, j], matmul[i, 0:j]], placement = gpu, memory = memsize)
                     def matmul_task():
-                        c_block[:] = (a_block @ b_block.T).array
+                        b_block_local = clone_here(b_block)
+                        c_block_local = clone_here(c_block)
+                        a_block_local = clone_here(a_block)
+                        c_block_local[:] = a_block_local @ b_block_local.T
                         # TODO(lhc): For now, do not copy back to cpu memory.
                         #            This is because I don't know how to move back to
                         #            PArray to CPU on nested task case.

--- a/parla/dataflow.py
+++ b/parla/dataflow.py
@@ -7,6 +7,36 @@ and also eager-fashion automatic data movement.
 from typing import Collection, Any
 from itertools import chain
 
+class DataflowIterator:
+    """
+    Itrator class for Dataflow.
+    """
+    def __init__(self, df):
+        self._df = df
+        self._idx = 0
+
+    def __next__(self):
+        """
+        Return the next value from Dataflow's data lists:
+        input -> output -> in/output lists
+        """
+        if self._idx < (len(self._df._input) + len(self._df._output) +
+                        len(self._df._inout)):
+            if self._idx < len(self._df._input):
+                # First, iterate input data operands.
+                cur_item = self._df._input[self._idx]
+            elif self._idx < (len(self._df._input) + len(self._df._output)):
+                # Second, iterate output data operands.
+                cur_item = self._df._output[self._idx - len(self._df._input)]
+            else:
+                # Third, iterate input/output data operands.
+                cur_item = self._df._inout[self._idx - len(self._df._input) -
+                                           len(self._df._output)]
+            self._idx += 1
+            return cur_item
+        raise StopIteration
+
+
 class Dataflow:
     """
     The data reference of input/output/inout of a task
@@ -24,3 +54,6 @@ class Dataflow:
         """
         for array in chain(self._input, self._output, self._inout):
             array._auto_move()
+
+    def __iter__(self):
+        return DataflowIterator(self)

--- a/parla/parray/core.py
+++ b/parla/parray/core.py
@@ -74,7 +74,12 @@ class PArray:
 
         Note: should not be called when the system has no GPU
         """
-        self.array = cupy.asarray(self.array)  # asarray by default copy to current device
+        if isinstance(self.array, numpy.ndarray):
+            self.array = cupy.asarray(self.array)
+        elif isinstance(self.array, cupy.ndarray):
+            dst = cupy.empty_like(self.array)
+            dst.data.copy_from_device_async(self.array.data, self.array.nbytes)
+            self.array = dst
 
     def _to_gpu(self, index: int) -> None:
         """

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1310,9 +1310,7 @@ class Scheduler(ControllableThread, SchedulerContext):
                     else:
                         # Create data movement tasks for each data
                         # operands of this task.
-                        for data in chain(task.dataflow._input,
-                                          task.dataflow._output,
-                                          task.dataflow._inout):
+                        for data in chain(task.dataflow):
                             self._construct_datamove_task(data, task)
 
                         # Only computation needs to set a assigned flag.

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1147,7 +1147,7 @@ class Scheduler(ControllableThread, SchedulerContext):
     _available_resources: ResourcePool
     period: float
 
-    def __init__(self, environments: Collection[TaskEnvironment], n_threads: int = None, period: float = 0.01):
+    def __init__(self, environments: Collection[TaskEnvironment], n_threads: int = None, period: float = 1.4012985e-20):
         # ControllableThread: __init__ sets it to run
         # SchedulerContext: No __init__
         super().__init__()

--- a/parla/tasks.py
+++ b/parla/tasks.py
@@ -16,7 +16,7 @@ from contextlib import asynccontextmanager, contextmanager, ExitStack
 from typing import Awaitable, Collection, Iterable, Optional, Any, Union, List, FrozenSet, Dict
 
 from parla.device import Device, Architecture, get_all_devices
-from parla.task_runtime import TaskID, TaskCompleted, TaskRunning, TaskAwaitTasks, TaskState, DeviceSetRequirements, Task, get_scheduler_context, task_locals
+from parla.task_runtime import TaskID, TaskCompleted, TaskRunning, TaskAwaitTasks, TaskState, DeviceSetRequirements, Task, get_scheduler_context, task_locals, wait_dependees_collection
 from parla.utils import parse_index
 from parla.dataflow import Dataflow
 
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "TaskID", "TaskSpace", "spawn", "get_current_devices", "tasks", "finish", "CompletedTaskSpace", "Task", "reserve_persistent_memory"
 ]
-
 
 class TaskSet(Awaitable, Collection, metaclass=ABCMeta):
     """
@@ -53,11 +52,12 @@ class TaskSet(Awaitable, Collection, metaclass=ABCMeta):
                 ds = (ds,)
             for d in ds:
                 if hasattr(d, "task"):
-                    d = d.task
-                if not isinstance(d, task_runtime.Task):
-                    raise TypeError("Dependencies must be TaskIDs or Tasks: " + str(d))
+                    if d.task is not None:
+                        d = d.task
+                #if not isinstance(d, task_runtime.Task):
+                #    raise TypeError("Dependencies must be TaskIDs or Tasks: " + str(d))
                 deps.append(d)
-        return tuple(deps)
+        return deps
 
     def __await__(self):
         return (yield TaskAwaitTasks(self._flat_tasks, None))
@@ -213,6 +213,63 @@ def _task_callback(task, body) -> TaskState:
                 in_value = in_value_task and in_value_task.result
                 logger.debug("Executing coroutine task: %s with input %s from %r", task.taskid,
                              in_value_task, in_value)
+
+                # This body returns information of the function body, not task.
+                # It means that any task shares the same function body can use the
+                # same information. This should be handled in more detailed.
+                # For example, dependencies could include TaskID, not Task objects
+                # if threads try to spawn several tasks sharing the same body with
+                # different task space, and if one tries to make dependency with
+                # nested tasks of the previous task.
+                # This could happen since the nested tasks could be spawned in parallel.
+                # To be specific, let's consider the below case.
+                #
+                # outer_task = TaskSpace("outer")
+                # inner_task = TaskSpace("inner")
+                # for rep in range(reps):
+                #     dep = [inner_task[rep - 1]] if rep > 0 else []
+                #     @spawn(out_task[rep], dependencies=[dep])
+                #     def t:
+                #         @spawn(inner_task[rep]):
+                #         def inner_t:
+                #         ...
+                #
+                # In the above case, the main thread will try to spawn
+                # out_task[0], and out_task[1] immediately.
+                # (Note that there is no await statement in the above)
+                #
+                # Let's assume that threads try to spawn tasks in this order
+                # at the first round:
+                # by main thread             -> by another thread
+                # out_task[0] -> out_task[1] -> inner_task[0]
+                #
+                # out_task[1] needs inner_task[0].
+                # But inner_task[0] is not yet spawned.
+                # out_task[1] is waiting for inner_task[0]'s spawn.
+                # out_task[0] gets a thread who runs it.
+                # When the thread tries to run out_task[0], it gets meta information
+                # from body.
+                # Since out_task[1] already requests inner_task[0] as a dependent task,
+                # inner_task[0] exists on TaskAwaitTasks, as TaskID, not Task.
+                # (Note that Task is mapped to TaskID after the task is spawnd).
+                #
+                # In this case, Parla removes that unspawned task id from
+                # the current dependency list. (in this case, out_task[0])
+                # This does not cause a problem because,
+                #
+                # First, any task whose have unspawned dependencies will never get
+                # this place. Also this unspawned dependencies are removed and do not
+                # exist on the task's dependency list.
+                #
+                # Second, if any task is ready to run after all dependencies are spawned,
+                # it will re-adds those removed/late spawned dependencies to its dependency
+                # list. (which means that removing the dependency from body's
+                # dependency list is fine)
+                #
+                # Therefore, non-Task or DataMovementTask elements of dependencies
+                # are fine even though it removes them at HERE.
+                #
+                # TODO(lhc): if you think wrong, please let me know.
                 new_task_info = body.send(in_value)
                 task.value_task = None
                 if not isinstance(new_task_info, TaskAwaitTasks):
@@ -289,7 +346,7 @@ def spawn(taskid: Optional[TaskID] = None, dependencies = (), *,
     The declared task (`t` above) can be used as a dependency for later tasks (in place of the tasks ID).
     This same value is stored into the task space used in `taskid`.
 
-    :see: :ref:`Fox's Algorithm` Example
+    :not see: :ref:`Fox's Algorithm` Example
 
     """
     # :param vcus: The amount of compute power this task uses. It is specified in "Virtual Compute Units".
@@ -323,6 +380,24 @@ def spawn(taskid: Optional[TaskID] = None, dependencies = (), *,
         # Compute the flat dependency set (including unwrapping TaskID objects)
         deps = tasks(*dependencies)._flat_tasks
 
+        # _flat_tasks appends two types of objects to deps.
+        # If a task corresponding to a task id listed on the dependencies
+        # is already spawned (materialized), it appends the task object.
+        # Otherwise, a task corresponding to the task id is not yet spawned
+        # and, in this case, appends its id which is not spawned yet as a key,
+        # and the dependee task id which waits for the dependent task to the
+        # wait_dependees_collection dictionary wrapper.
+        # The tasks on that dictionary is not spawned until all
+        # dependent tasks are spawned.
+        num_unspawned_deps = 0
+        for dep in list(deps):
+            if type(dep) is TaskID:
+                # If the dep is not yet spawned, temporarily removes it from
+                # a task's dependency list.
+                deps.remove(dep)
+                num_unspawned_deps += 1
+                wait_dependees_collection.append_wait_task(dep, taskid)
+
         if inspect.iscoroutine(body):
             # An already running coroutine does not need changes since we assume
             # it was changed correctly when the original function was spawned.
@@ -345,15 +420,26 @@ def spawn(taskid: Optional[TaskID] = None, dependencies = (), *,
         # gather input/output/inout, which is hint for data from or to the this task
         dataflow = Dataflow(input, output, inout)
 
-        # Spawn the task via the Parla runtime API
-        task = task_runtime.get_scheduler_context().spawn_task(
-            function=_task_callback,
-            args=(separated_body,),
-            deps=deps,
-            taskid=taskid,
-            req=req,
-            dataflow=dataflow,
-            name=getattr(body, "__name__", None))
+        if num_unspawned_deps == 0:
+          # Spawn the task via the Parla runtime API
+          task = task_runtime.get_scheduler_context().spawn_task(
+              function=_task_callback,
+              args=(separated_body,),
+              deps=deps,
+              taskid=taskid,
+              req=req,
+              dataflow=dataflow,
+              name=getattr(body, "__name__", None))
+        else:
+          task = task_runtime.get_scheduler_context().create_wait_task(
+              function=_task_callback,
+              args=(separated_body,),
+              deps=deps,
+              taskid=taskid,
+              req=req,
+              dataflow=dataflow,
+              num_unspawned_deps=num_unspawned_deps,
+              name=getattr(body, "__name__", None))
 
         logger.debug("Created: %s %r", taskid, body)
 


### PR DESCRIPTION
This PR updates data movement tasks which were one for each computation task to be one for each computation task's OPERANDS. Expected benefits from these updates are that each data movement task could have different dependencies and could be done earlier than the corresponding parent task (the computation task).

This PR touches data flow graph to support iterator iterating all three data operand lists.

This PR also touches PArray to provide stable data movements from GPU to other GPUs.

Lastly, this PR adds new matmul using explicit data movements as a comparator to matmul_automove.
Both applications are modified to start from CPU memory and give explicit dependencies.
One thing that I failed is to copy back to result (C blocks) to CPU memory since I don't know how to do this by PArray on nested tasks. (Just auto_move() after the inner task didn't work.)
But for performance comparisons, it is not necessary. They can be ignored for now.
