### PR TITLE
Launch phase uses device queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/build
 # IDE
 .idea
 .vscode
+
+# Vim temp files
+*.swp

--- a/parla/__init__.py
+++ b/parla/__init__.py
@@ -22,7 +22,6 @@ class Parla:
         i = 0
         task_envs = []
         for d in get_all_devices():
-            print("env_no:", i, " is added to Parla environments")
             task_envs.append(TaskEnvironment(placement=[d], env_no=i))
             i+=1
         self.environments = task_envs

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1,4 +1,3 @@
-import abc
 import logging
 import random
 from abc import abstractmethod, ABCMeta
@@ -7,12 +6,9 @@ from contextlib import contextmanager
 import threading
 import time
 from itertools import combinations
-from numbers import Number
-from threading import Thread, Condition
 from typing import Optional, Collection, Union, Dict, List, Any, Tuple, FrozenSet, Iterable, TypeVar, Deque
-import concurrent.futures
 
-from parla.device import get_all_devices, Device, Architecture
+from parla.device import get_all_devices, Device
 from parla.environments import TaskEnvironmentRegistry, TaskEnvironment
 from parla.dataflow import Dataflow
 
@@ -33,7 +29,7 @@ _ASSIGNMENT_FAILURE_WARNING_LIMIT = 32
 TaskAwaitTasks = namedtuple("AwaitTasks", ("dependencies", "value_task"))
 
 
-class TaskState(object, metaclass=abc.ABCMeta):
+class TaskState(object, metaclass=ABCMeta):
     __slots__ = []
 
     @property
@@ -95,7 +91,7 @@ class TaskException(TaskState):
 ResourceDict = Dict[str, Union[float, int]]
 
 
-class ResourceRequirements(object, metaclass=abc.ABCMeta):
+class ResourceRequirements(object, metaclass=ABCMeta):
     __slots__ = ["resources", "ndevices", "tags"]
 
     tags: FrozenSet[Any]
@@ -749,7 +745,7 @@ def get_devices() -> Collection[Device]:
     return _scheduler_locals.environment.placement
 
 
-class ControllableThread(Thread, metaclass=ABCMeta):
+class ControllableThread(threading.Thread, metaclass=ABCMeta):
     _should_run: bool
     _monitor: threading.Condition
 
@@ -853,7 +849,7 @@ class WorkerThread(ControllableThread, SchedulerContext):
 
 class ResourcePool:
     _multiplier: float
-    _monitor: Condition
+    _monitor: threading.Condition
     _devices: Dict[Device, Dict[str, float]]
 
 


### PR DESCRIPTION
Prior to this, there were no queue structures associated with devices. Rather, WorkerThreads had queues (of depth 2). The schedudler would queue up work onto the thread and threads would run tasks that had been assigned to them.

Since threads shouldn't be treated as finite resources, but devices should, we now queue up work on devices instead. (This is the model we discussed in the past few meetings - see attached image).
![scheduler](https://user-images.githubusercontent.com/21699612/152600862-7ff669f6-331f-484c-82cc-7cfa1c8a8597.PNG)

[5ecad4b](https://github.com/ut-parla/Parla.py/pull/99/commits/5ecad4bb16fb0b428355dc87f9d7a3eb1c0f77c5) is just a bunch of comments and a name change (allocation queue -> ready queue). Not much need for review here.

[bbcfffa](https://github.com/ut-parla/Parla.py/pull/99/commits/bbcfffad2834a5d9fb7669ea0dcafe63dfd64637) is just a .gitignore update because I use Vim and didn't want to push *.swp files to the repo.

[97350f8](https://github.com/ut-parla/Parla.py/pull/99/commits/97350f80965e4c3a14f3a59e36d2c438f6a0ff44) is the main set of changes. I recommend starting on like 1271 when reviewing. I've reworked major portions of the WorkerThread class to take only one task rather than acting as a queue. I've updated the scheduler launch function to iterate device queues and pop work as necessary. I've also added a dict storing whether or not each device is busy as a temporary workaround.