### PR TITLE
Loosen restraint to allow concurrent data movement tasks if parent tasks have dependency

### DIFF
--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1273,9 +1273,6 @@ class Scheduler(ControllableThread, SchedulerContext):
                     if not datamove_task._add_dependency(dep_task):
                         completed_tasks.append(dep_task_id)
             dep_task_list = [tuple(dt for dt in dep_task_list if dt[0] != ft) for ft in completed_tasks]
-            print("++!! Creating DataMoveTask", taskid, "VALUE: ", target_data._array," :: dependencies - ", dep_list, "built from: ", compute_task._taskid, flush=True)
-        else:
-            print("++!! Creating DataMoveTask :: no dependencies, built from: ", compute_task._taskid, flush=True)
 
         if operand_type != OperandType.IN:
             self._datablock_dict[target_data_id].append((str(compute_task.taskid), compute_task))


### PR DESCRIPTION
![task](https://user-images.githubusercontent.com/9628770/159203959-dea17f86-8cbf-4112-a5f0-a10af851dd66.png)

^ removing red edges in this picture, to allow blue edges to happen concurrently. 

This makes all data movement tasks reads only. 
Write invalidation is moved to when a compute_task starts. 

Note atm.... Parrays still have a global lock, so concurrent reads can't happen in practice. This should be fixed in the same PR slicing is added. 