### PR TITLE
Mapper memory tracking and policy updates

### DIFF
--- a/parla/parray/core.py
+++ b/parla/parray/core.py
@@ -82,6 +82,9 @@ class PArray:
 
             # Public API:
 
+    def exists_on_device(self, device_id):
+        return (self._array[device_id] is not None)
+
     def update(self, array) -> None:
         """ Update the copy on current device.
 

--- a/parla/parray/core.py
+++ b/parla/parray/core.py
@@ -45,6 +45,8 @@ class PArray:
 
         self._coherence_lock = threading.Lock()  # a lock to greb when update coherence and move data
 
+        self.size = array.size
+
     # Properties:
 
     @property
@@ -89,6 +91,8 @@ class PArray:
         Note: should be called within the current task context
         Note: data should be put in OUT/INOUT fields of spawn
         """
+        self.size = array.size
+
         this_device = self._current_device_index
 
         if isinstance(array, numpy.ndarray):

--- a/parla/parray/core.py
+++ b/parla/parray/core.py
@@ -46,6 +46,7 @@ class PArray:
         self._coherence_lock = threading.Lock()  # a lock to greb when update coherence and move data
 
         self.size = array.size
+        self.nbytes = array.nbytes
 
     # Properties:
 
@@ -95,6 +96,7 @@ class PArray:
         Note: data should be put in OUT/INOUT fields of spawn
         """
         self.size = array.size
+        self.nbytes = array.nbytes
 
         this_device = self._current_device_index
 

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1,3 +1,4 @@
+# General imports
 from functools import lru_cache
 import logging
 import random
@@ -10,19 +11,17 @@ import time
 from itertools import combinations
 from typing import Optional, Collection, Union, Dict, List, Any, Tuple, FrozenSet, Iterable, TypeVar, Deque
 
+# Parla imports
 from parla.device import get_all_devices, Device
 from parla.environments import TaskEnvironmentRegistry, TaskEnvironment
-
 from parla.cpu_impl import cpu
 
+# Logger configuration (uncomment and adjust level if needed)
 #logging.basicConfig(level = logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 __all__ = ["Task", "SchedulerContext", "DeviceSetRequirements", "OptionsRequirements", "ResourceRequirements", "get_current_devices"]
-
-# TODO: This module is pretty massively over-engineered the actual use case could use a much simpler scheduler.
-
-_ASSIGNMENT_FAILURE_WARNING_LIMIT = 32
 
 
 # Note: tasks can be implemented as lock free, however, atomics aren't really a thing in Python, so instead

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -15,7 +15,6 @@ from typing import Optional, Collection, Union, Dict, List, Any, Tuple, FrozenSe
 from parla.device import get_all_devices, Device
 from parla.environments import TaskEnvironmentRegistry, TaskEnvironment
 from parla.cpu_impl import cpu
-from parla.cuda import gpu
 
 # Logger configuration (uncomment and adjust level if needed)
 #logging.basicConfig(level = logging.INFO)
@@ -986,7 +985,7 @@ class ResourcePool:
                 dres = self._devices[d]
 
                 # Workaround stupid vcus (I'm getting rid of these at some point)
-                if d.architecture == gpu and name == 'vcus':
+                if d.architecture.id == 'gpu' and name == 'vcus':
                     continue
 
                 if amount > dres[name]:
@@ -1021,7 +1020,7 @@ class ResourcePool:
 
     def _update_resource(self, dev: Device, res: str, amount: float, block: bool):
         # Workaround stupid vcus (I'm getting rid of these at some point)
-        if dev.architecture == gpu and res == 'vcus':
+        if dev.architecture.id == 'gpu' and res == 'vcus':
             return True
         try:
             while True: # contains return
@@ -1049,7 +1048,7 @@ class ResourcePool:
     def _to_parray_index(self, device):
         if device.architecture == cpu:
             return self.CPU_INDEX
-        if device.architecture == gpu:
+        if device.architecture.id == 'gpu':
             return device.index
         raise NotImplementedError("Only cpu and gpu architectures are supported")
 

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -379,7 +379,7 @@ class Task:
 
     def _check_remaining_dependencies(self):
         if not self._remaining_dependencies and self.assigned:
-            logger.info("[Task] %s: Scheduling", self._name)
+            logger.info("[Task] %s: Scheduling", str(self.taskid))
             get_scheduler_context().enqueue_task(self)
 
     def bool_check_remaining_dependencies(self):
@@ -432,7 +432,7 @@ class Task:
 
     def _set_state(self, new_state: TaskState):
         # old_state = self._state
-        logger.info("[Task] %r: %r -> %r", self._name, self._state, new_state)
+        logger.info("[Task] %r: %r -> %r", str(self._taskid), self._state, new_state)
         self._state = new_state
         ctx = get_scheduler_context()
 

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -989,6 +989,11 @@ class ResourcePool:
             is_available = True
             for name, amount in resources.items():
                 dres = self._devices[d]
+
+                # Workaround stupid vcus (I'm getting rid of these at some point)
+                if d.architecture == gpu and name == 'vcus':
+                    continue
+
                 if amount > dres[name]:
                     is_available = False
                 logger.debug("Resource check for %d %s on device %r: %s", amount, name, d, "Passed" if is_available else "Failed")
@@ -1020,6 +1025,9 @@ class ResourcePool:
             return success
 
     def _update_resource(self, dev: Device, res: str, amount: float, block: bool):
+        # Workaround stupid vcus (I'm getting rid of these at some point)
+        if dev.architecture == gpu and res == 'vcus':
+            return True
         try:
             while True: # contains return
                 dres = self._devices[dev]

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1,3 +1,8 @@
+# MAJOR TODO:
+# 1) Check on memory allocation/deallocation everywhere. Don't double count resource usage.
+# 2) Tasks need to update the ResourcePool's size of their inout/out parrays
+# 3) Dependent tasks need increased affinity to the device of their dependencies if using same data
+
 # General imports
 from functools import lru_cache
 import logging
@@ -587,6 +592,7 @@ class DataMovementTask(Task):
         try:
             # Allocate the resources used by this task (blocking)
             for d in self.req.devices:
+                # TODO: Don't double count resources
                 ctx.scheduler._available_resources.allocate_resources(d, self.req.resources, blocking=True)
             # Run the task and assign the new task state
             try:
@@ -1318,8 +1324,11 @@ class Scheduler(ControllableThread, SchedulerContext):
             def myformat(num):
                 return "{:.3f}".format(num)
 
-            print(f"local={myformat(local_data)}   nonlocal={myformat(nonlocal_data)}   \
-                    load={myformat(dev_load)}   suit={myformat(suitability)}")
+            print(f"dev={device}   \
+                    local={myformat(local_data)}   \
+                    nonlocal={myformat(nonlocal_data)}   \
+                    load={myformat(dev_load)}   \
+                    suit={myformat(suitability)}")
             """
 
             # Update whether or not this is the most suitable device

--- a/parla/tasks.py
+++ b/parla/tasks.py
@@ -418,6 +418,7 @@ def spawn(taskid: Optional[TaskID] = None, dependencies = (), *,
         taskid.dependencies = dependencies
 
         # gather input/output/inout, which is hint for data from or to the this task
+        # TODO (ses): I gathered these into lists so I could perform concatentation later. This may be inefficient.
         dataflow = Dataflow(list(input), list(output), list(inout))
 
         if num_unspawned_deps == 0:

--- a/parla/tasks.py
+++ b/parla/tasks.py
@@ -418,7 +418,7 @@ def spawn(taskid: Optional[TaskID] = None, dependencies = (), *,
         taskid.dependencies = dependencies
 
         # gather input/output/inout, which is hint for data from or to the this task
-        dataflow = Dataflow(input, output, inout)
+        dataflow = Dataflow(list(input), list(output), list(inout))
 
         if num_unspawned_deps == 0:
           # Spawn the task via the Parla runtime API


### PR DESCRIPTION
- Added new mapper algorithm to find device with best suitability based on load, local data, and dependency location
- Got the new mapper algorithm to properly assign devices to tasks
   - Mapper creates a new TaskEnvironment with chosen device, just like in the old system
- Updated resource allocation/deallocation calls to be consistent throughout task_runtime.py
   - All resources are allocated within the map phase after placements are chosen
   - All resources are deallocated on task cleanup
   - VCUs have no effect on GPU devices at the moment
- Updated parray tracking in task_runtime.py
   - At the end of a task, all of the task's OUT/INOUT parrays have their tracking updated in case their size changed or their coherence updated
- Modified device affinity for tasks with dependencies
   - If you have a dependency task running on one device AND more data on that device than elsewhere, always run there regardless of load
- Tested the above changes on synthetic serial graph, synthetic independent graph, matmul_automove, and blocked_cholesky_parray