### PR TITLE
Changing launch mechanism to worker thread callbacks

### DIFF
--- a/parla/cpu_impl.py
+++ b/parla/cpu_impl.py
@@ -15,11 +15,13 @@ __all__ = ["cpu"]
 logger = logging.getLogger(__name__)
 
 
-_MEMORY_FRACTION = 15/16 # The fraction of total memory Parla should assume it can use.
+# The fraction of total memory Parla should assume it can use.
+_MEMORY_FRACTION = 15/16
 
 
 def get_n_cores():
-    return psutil.cpu_count(logical=False)
+    cores = os.environ.get("PARLA_CORES", psutil.cpu_count(logical=False))
+    return int(cores)
 
 
 def get_total_memory():
@@ -33,7 +35,8 @@ class _CPUMemory(Memory):
 
     def __call__(self, target):
         if getattr(target, "device", None) is not None:
-            logger.debug("Moving data: %r => CPU", getattr(target, "device", None))
+            logger.debug("Moving data: %r => CPU",
+                         getattr(target, "device", None))
         return array.asnumpy(target)
 
 
@@ -41,11 +44,12 @@ class _CPUDevice(Device):
     def __init__(self, architecture: "Architecture", index, *args, n_cores, **kws):
         super().__init__(architecture, index, *args, **kws)
         self.n_cores = n_cores or get_n_cores()
-        self.available_memory = get_total_memory()*_MEMORY_FRACTION / get_n_cores() * self.n_cores
+        self.available_memory = get_total_memory()*_MEMORY_FRACTION / \
+            get_n_cores() * self.n_cores
 
     @property
     def resources(self) -> Dict[str, float]:
-        return dict(threads=self.n_cores, memory=self.available_memory, vcus=self.n_cores)
+        return dict(cores=self.n_cores, memory=self.available_memory, vcus=1)
 
     @property
     def default_components(self) -> Collection["EnvironmentComponentDescriptor"]:
@@ -76,6 +80,7 @@ class _CPUCoresArchitecture(_GenericCPUArchitecture):
     """
     The number of cores for which this process has affinity and are exposed as devices.
     """
+
     def __init__(self, name, id):
         super().__init__(name, id)
         self._devices = [self(i) for i in range(self.n_cores)]
@@ -103,6 +108,7 @@ class _CPUWholeArchitecture(_GenericCPUArchitecture):
     """
     The number of cores for which this process has affinity and are exposed as VCUs.
     """
+
     def __init__(self, name, id):
         super().__init__(name, id)
         self._device = self(0)
@@ -179,4 +185,3 @@ cpu.__doc__ = """The `~parla.device.Architecture` for CPUs.
 
 >>> cpu()
 """
-

--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1803,7 +1803,7 @@ class Scheduler(ControllableThread, SchedulerContext):
             return self._device_launched_compute_task_counts[dev]
 
     def get_launched_datamove_task_count(self, dev):
-        with self._launced_count_monitor[dev]:
+        with self._launched_count_monitor[dev]:
             return self._device_launched_datamove_task_counts[dev]
 
     def update_mapped_task_count_mutex(self, task, dev, counts):


### PR DESCRIPTION
NOTE: DRAFT PR, DO NOT MERGE. 
Lots of debugging and optimization left to do. Making this PR early so people can edit and comment. 

Also note: This does not fix any bugs in dev, all bugs present in dev should still occur here.  

The scheduling phases have been moved out of the scheduler thread loop into 'worker.run' and the 'spawn' decorator. 
These are 'launch_tasks_callback', 'schedule_tasks_callback', and 'map_tasks_callback'. 
Each has a non-blocking lock such that only 1 worker thread can access each phase at a time. 
Each has some condition that needs to be met for each phase to run. These are currently set to the greediest possible conditions. They will run as long as there might be work available to schedule. 

I have not yet completely killed the old scheduler thread itself. Right now, it just releases the GIL and does nothing. 
When I try to remove it it either:
 (1) makes execution slower or 
 (2) I'm worried about breaking the final runtime synchronization step in scheduler `__exit__`. 

Additionally:
- I have made separate locks for all of the separate counter and queues to prevent contention. 
  (This has significant performance improvements when used with the old scheduler style loop)
- VCUs have been added back in. 

I have only tested on GPU Cholesky 10k, 14k, 20k locally and on Frontera for correctness.
On these tests it is about as fast as the current dev. Although the callback scheduler appears to have higher variability. 

- Synthetic testing is still needed
- CPU testing is still needed. 
- Nested Task testing is still needed

This might currently fail for tasks that are spawned out of dependency order as the first callback will be missed. 