### PR TITLE
Fix scheduler early termination bug

### DIFF
--- a/parla/tasks.py
+++ b/parla/tasks.py
@@ -434,9 +434,7 @@ def spawn(taskid: Optional[TaskID] = None,
             scope.append(task)
 
         # Activate scheduler
-        scheduler.map_tasks_callback()
-        scheduler.schedule_tasks_callback()
-        scheduler.launch_tasks_callback()
+        scheduler.start_scheduler_callbacks()
 
         # Return the task object to user code
         return task


### PR DESCRIPTION
The current callback-based scheduler terminates earlier before all tasks complete.
Below scenario is the main reason:

1. One thread, t0, starts a launch step. It acquires a launch lock.
2. Other free thread tries to enter the launch step. But it skips that since t0 already got the lock.
3. t0 finishes the step's main loop (but not release the lock yet).
4. At the same time, a running task completes, notifies its dependent tasks, and tasks whose all dependencies are resolved are enqueued onto a device queue.
5. But, t0 releases the lock after it exited the loop, and no threads could enter the mutual section. There is no free thread to start the callbacks, but the enqueued tasks are still remained.

To resolve this problem, we need to integrate all callbacks into a single mutual section. And we need to change non-blocking lock to blocking lock.