### PR TITLE
fix: bug on writeback subarray deadlock

### DIFF
--- a/parla/parray/core.py
+++ b/parla/parray/core.py
@@ -367,7 +367,8 @@ class PArray:
                     self._coherence_cv[op.dst].notify_all()  # let other threads know the data is ready
             elif op.inst == MemoryOperation.EVICT:
                 self._array.clear(op.src)  # decrement the reference counter, relying on GC to free the memory
-                self._coherence.set_data_as_ready(op.src, None)  # mark it as done
+                if MemoryOperation.NO_MARK_AS_READY not in op.flag:
+                    self._coherence.set_data_as_ready(op.src, None)  # mark it as done
             elif op.inst == MemoryOperation.ERROR:
                 raise RuntimeError("PArray gets an error from coherence protocol")
             else:


### PR DESCRIPTION
Example:
at begin: CPU has complete copy, GPU 0 has dirty subarray

then: GPU 0 read the whole array
what happen: GPU 0 subarray write back to CPU, then GPU 0 copy back from CPU
previous logic has a deadlock that CPU wait on GPU 0 to be ready and GPU 0 wait on CPU to be ready.