### PR TITLE
Remove incorrect task mapping flag setting 

### DIFF
--- a/parla/task_runtime.py
+++ b/parla/task_runtime.py
@@ -1744,8 +1744,6 @@ class Scheduler(ControllableThread, SchedulerContext):
         task_env = next(task_env_gen)
         task.req = EnvironmentRequirements(
             task.req.resources, task_env, task.req.tags)
-
-        task.set_assigned()
         logger.debug(f"[Scheduler] Mapped %r to %r.", task, best_device)
         return True
 
@@ -1815,8 +1813,6 @@ class Scheduler(ControllableThread, SchedulerContext):
         task_env = next(task_env_gen)
         task.req = EnvironmentRequirements(
             task.req.resources, task_env, task.req.tags)
-
-        task.set_assigned()
         logger.debug(f"[Scheduler] RANDOMLY Mapped %r to %r.",
                      task, best_device)
         return True


### PR DESCRIPTION
These flag setting causes an error that enqueues tasks whose data movement tasks are not yet created to ready queues, while dependencies notify them. It is dangerous since data movements are not happened. A solution is to set the flag after data movement tasks are created.