### PR TITLE
fix: a bug when using parray slicing within spawn

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,3 +75,20 @@ jobs:
 
       - name: Run Figure 14
         run: python3 examples/launcher.py --figure 14
+
+  parray_test:
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Run Automove Test
+        run: python3 tests/test_automove.py
+      
+      - name: Run Fine Grained Parray Test
+        run: python3 tests/test_fine_grained_parray.py
+
+      - name: Run Reduction Test
+        run: python3 tests/test_reduction.py

--- a/parla/parray/coherence.py
+++ b/parla/parray/coherence.py
@@ -539,7 +539,7 @@ class Coherence:
         if device_local_state == self.INVALID: # already evicted, do nothing
             operations.append(MemoryOperation.noop())
         elif device_local_state == self.SHARED:
-            if device_id == self._owner:  # has a chance this is the last copy
+            if device_id == self.owner:  # has a chance this is the last copy
                 # find new owner
                 new_owner = None
                 for device, state in self._local_states.items():
@@ -565,20 +565,20 @@ class Coherence:
                             new_owner = CPU_INDEX
                     else:
                         self._global_state = self.INVALID  # the system lose the last copy
-                self._owner = new_owner
+                self.owner = new_owner
 
             # update states
             self._local_states[device_id] = self.INVALID
             operations.append(MemoryOperation.evict(device_id))
         else:  # Modified, this device owns the last copy
             if keep_one_copy:  # write back to CPU
-                self._owner = CPU_INDEX
+                self.owner = CPU_INDEX
                 self._local_states[CPU_INDEX] = self.MODIFIED
 
                 operations.append(MemoryOperation.load(CPU_INDEX, device_id))
             else:
                 self._global_state = self.INVALID  # the system lose the last copy
-                self._owner = None
+                self.owner = None
 
             self._local_states[device_id] = self.INVALID
             operations.append(MemoryOperation.evict(device_id))

--- a/parla/parray/core.py
+++ b/parla/parray/core.py
@@ -218,7 +218,12 @@ class PArray:
             ret = self._array.get_by_global_slices(self._current_device_index, slices)
 
         # ndarray.__getitem__() may return a ndarray
-        if isinstance(ret, numpy.ndarray):
+        if ret is None:
+            # when current device has no copy (could happen when a slice annotation is needed at @spawn)
+            # get ret from owner, so it could have an estimation of the number of bytes used
+            ret = self._array.get_by_global_slices(self._coherence.owner, slices)
+            return PArray(ret, parent=self, slices=slices)
+        elif isinstance(ret, numpy.ndarray):
             return PArray(ret, parent=self, slices=slices)
         elif isinstance(ret, cupy.ndarray):
             if ret.shape == ():

--- a/tests/test_reduction.py
+++ b/tests/test_reduction.py
@@ -1,0 +1,163 @@
+"""
+This script tests the evaluation of a multi-device reduction using
+PArrays. The reduction involves a multi-dimensional array and sums
+across the device memory, storing the final result in a PArray.
+"""
+
+import argparse
+import os
+from os.path import expanduser, join
+import sys
+
+# Parse the command line data
+parser = argparse.ArgumentParser(description='Multi-GPU reduction using PArrays')
+parser.add_argument('-ngpus', type=int,
+                    default=2, help="Number of gpus to use.")
+parser.add_argument('-blocks', type=int, 
+                    default=2, help="Number of element blocks/partitions.")
+parser.add_argument('-trials', type=int,
+                    default=2, help="Number of repititions for timing regions of code.")
+parser.add_argument('-N', type=int,
+                    default=10, help="Number of elements/block.")
+
+args = parser.parse_args()
+
+# Display the arguments in the console
+print("\nOptions used:\n")
+
+for arg in vars(args):
+    print(arg, "=", getattr(args, arg))
+
+print("\n")
+
+ngpus = args.ngpus
+blocks = args.blocks
+trials = args.trials
+N = args.N
+
+# Error checking for the input
+assert blocks >= ngpus, "Error: blocks >= ngpus.\n"
+
+# Specify information about the devices
+cuda_visible_devices = os.environ.get('CUDA_VISIBLE_DEVICES')
+
+if cuda_visible_devices is None:
+    print("CUDA_VISIBLE_DEVICES is not set. Assuming 0-3")
+    cuda_visible_devices = list(range(4))
+else:
+    cuda_visible_devices = cuda_visible_devices.strip().split(',')
+    cuda_visible_devices = list(map(int, cuda_visible_devices))
+
+gpus = cuda_visible_devices[:ngpus]
+os.environ['CUDA_VISIBLE_DEVICES'] = ','.join(map(str, gpus))
+
+dirname = os.path.dirname(__file__)
+parla_dir = dirname + "/../Parla.py/"
+sys.path.append(parla_dir)
+
+import numpy as np
+import cupy as cp
+import numba as nb
+from numba import cuda
+import time
+
+# Parla modules and decorators
+# These should be imported after "CUDA_VISIBLE_DEVICES" is set
+from parla import Parla, get_all_devices, parray
+from parla.cpu import cpu
+from parla.cuda import gpu
+from parla.tasks import spawn, TaskSpace
+
+def main():
+
+    @spawn(placement=cpu)
+    async def main_task():
+
+        # Create a 2-D array on the host then
+        # wrap it with a PArray
+        A = np.zeros([blocks,N], dtype=np.int64)
+        A_pa = parray.asarray(A)
+
+        # Create the PArray that will hold the reduction
+        reduction_result_pa = parray.asarray( np.zeros([N]) )
+        print(f"1 reduction_result_pa: {reduction_result_pa}")
+
+        # Each row of the array A will be the row_id
+        # When we sum down the rows for the reduction
+        # the correct answer is (blocks - 1)*(blocks)/2
+        solution = (blocks - 1)*(blocks)/2
+
+        print("Solution for this configuration:", solution, "\n")
+
+        # Create the task space for Parla
+        sts = TaskSpace("SetupTaskSpace")
+        rts = TaskSpace("ReductionTaskSpace")
+
+        # Store the times for statistics
+        parla_times = np.zeros([trials]) 
+
+        for trial_idx in range(trials):
+
+            # Setup the array
+            for i in range(blocks):
+                print(f"{i}")
+                # Map the block to a specific device
+                dev_idx = i % ngpus
+                
+                # Set the values in the PArray to be the block idx
+                @spawn(taskid=sts[trial_idx,i], placement=gpu[dev_idx], output=[A_pa[i]])
+                def init_task():
+                    print(f"initialize i: {i}, dev_id: {dev_idx}")
+                    A_pa[i][:] = i
+
+                await sts
+    
+            # Now print the value of the PArray to the console for inspection
+            print("Initialization is complete. Printing the output now...\n")
+            print("A_pa =", A_pa, "\n")
+            print("Preparing to start the reduction task.\n")
+
+            parla_start = time.perf_counter()
+
+            # Perform the reduction of the PArray on the device
+            @spawn(taskid=rts[trial_idx], placement=gpu[0], input=[A_pa], 
+                   output=[reduction_result_pa], dependencies=[sts[trial_idx,0:blocks]])
+            def reduction_task():
+
+                # We can use the update() method here since the result array is write-only
+                print(f"cp.sum(A_pa.array, axis=0): {cp.sum(A_pa.array, axis=0)}")
+                print(f"2 reduction_result_pa: {reduction_result_pa}")
+                reduction_result_pa[:] = cp.sum(A_pa.array, axis=0)
+                print(f"3 reduction_result_pa: {reduction_result_pa}")
+                print(f"A_pa: {A_pa}")
+
+            await rts
+
+            parla_end = time.perf_counter()
+            parla_times[trial_idx] = parla_end - parla_start
+
+        # End of the trial loop
+
+        dts = TaskSpace("DataTaskSpace")
+        @spawn(taskid=dts[0], placement=cpu, input=[reduction_result_pa])
+        def gather_data():
+            pass
+        
+        await dts
+
+        print("type( reduction_result_pa.array ) =", type( reduction_result_pa.array ) )
+        print("reduction_result_pa.array  =", reduction_result_pa.array )
+
+        print("Parla times (min, max, avg) [s] ", parla_times.min(),",",
+        parla_times.max(),",", parla_times.mean(), "\n",flush=True)
+
+        # Check for correctness
+        print("Is the solution correct?", np.all(reduction_result_pa.array == solution), "\n")
+
+
+if __name__ == "__main__":
+
+    # First create the Parla context before spawning tasks
+    with Parla():
+
+        main()


### PR DESCRIPTION
sometimes device has no copy but still need a parray slices view object in advance.
So the mechanism is modified such that even if there is no copy on the device, it is still possible to slice a parray, which create a view of origin copy
Example:
```
A = parray(numpy_array)
@spawn(inout=[A], placement=gpu(0))
def task1():
    ... a task move A to GPU. free CPU copy ...
@spawn(inout=[A[0]], placement=gpu(1))
def task2():
    error: cpu's copy is freed -> `inout=[A[0]]` trigger an exception,
    since it try a slice A at CPU (spawn() itself is happened at outer CPU task)
```